### PR TITLE
Do not write YAML tags to instance and bindings

### DIFF
--- a/cli/test/instance.yml
+++ b/cli/test/instance.yml
@@ -27,7 +27,7 @@ serviceDefinition:
   metadata: {}
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 asyncAccepted: true

--- a/cli/test/osb-git/instances/159440dd-652a-4e2b-916e-9cd4dde33c33/instance.yml
+++ b/cli/test/osb-git/instances/159440dd-652a-4e2b-916e-9cd4dde33c33/instance.yml
@@ -58,7 +58,7 @@ serviceDefinition:
                   description: "Azure Region"
                   type: "string"
               type: object
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: "meshmarketplace"
   user_id: "502c9d14-db19-4e20-b71a-e3a0717bc0db"
   user_euid: "partner@meshcloud.io"
@@ -66,7 +66,7 @@ asyncAccepted: true
 parameters:
   cidr: "10.0.0.0/24"
   region: "eu-west"
-context: !<PlatformContext>
+context:
   platform: "meshmarketplace"
   permission_url: null
   project_id: "osb-dev"

--- a/cli/test/osb-git/instances/49c96fa5-46cc-4334-a718-378ceed2de81/instance.yml
+++ b/cli/test/osb-git/instances/49c96fa5-46cc-4334-a718-378ceed2de81/instance.yml
@@ -79,7 +79,7 @@ serviceDefinition:
     supportUrl: "https://azure.microsoft.com/en-us/services/devops/"
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: "meshmarketplace"
   user_id: "502c9d14-db19-4e20-b71a-e3a0717bc0db"
   user_euid: "partner@meshcloud.io"
@@ -89,7 +89,7 @@ parameters:
   projectdescription: "qwerqw"
   msteamsad: "PROD"
   email: "qwerqwer"
-context: !<PlatformContext>
+context:
   platform: "meshmarketplace"
   permission_url: null
   project_id: "osb-dev"

--- a/cli/test/osb-git/instances/eed1df43-e63c-40ad-995e-e21068254ef9/instance.yml
+++ b/cli/test/osb-git/instances/eed1df43-e63c-40ad-995e-e21068254ef9/instance.yml
@@ -79,7 +79,7 @@ serviceDefinition:
     supportUrl: "https://azure.microsoft.com/en-us/services/devops/"
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: "meshmarketplace"
   user_id: "502c9d14-db19-4e20-b71a-e3a0717bc0db"
   user_euid: "partner@meshcloud.io"
@@ -88,7 +88,7 @@ parameters:
   projectname: "test"
   projectdescription: "test"
   msteamsad: "TEST"
-context: !<PlatformContext>
+context:
   platform: "meshmarketplace"
   permission_url: null
   project_id: "osb-dev"

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/YamlHandler.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/YamlHandler.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -19,8 +20,9 @@ import java.io.FileWriter
 @Service
 class YamlHandler {
 
-  val yamlMapper = ObjectMapper(YAMLFactory())
-    .registerKotlinModule()
+  val yamlMapper = ObjectMapper(YAMLFactory()
+    .configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID,false) // Set to false, so that types are tagged inline
+  ).registerKotlinModule()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .registerModule(JavaTimeModule())
 

--- a/src/test/resources/expected_binding.yml
+++ b/src/test/resources/expected_binding.yml
@@ -3,11 +3,11 @@ bindingId: "7cbebf1f-f494-424f-9d65-c0a037257024"
 serviceInstanceId: "b80e0781-74fd-422c-89e9-def5e76a8128"
 serviceDefinitionId: "d40133dd-8373-4c25-8014-fde98f38a728"
 planId: "a13edcdf-eb54-44d3-8902-8f24d5acb07e"
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: "http://localhost:8080/serviceRegistry/location/1"
   user_id: "67c54164-8f7c-4a86-b0d8-0ecdd6510366"
 parameters: { }
-context: !<PlatformContext>
+context:
   platform: "http://localhost:8080/serviceRegistry/location/1"
   permission_url: null
   project_id: "managed-project"

--- a/src/test/resources/expected_instance.yml
+++ b/src/test/resources/expected_instance.yml
@@ -27,7 +27,7 @@ serviceDefinition:
   metadata: {}
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 asyncAccepted: true

--- a/src/test/resources/expected_instance_after_update.yml
+++ b/src/test/resources/expected_instance_after_update.yml
@@ -27,7 +27,7 @@ serviceDefinition:
   metadata: {}
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 asyncAccepted: true

--- a/src/test/resources/instances/testInstanceID/instance.yml
+++ b/src/test/resources/instances/testInstanceID/instance.yml
@@ -27,7 +27,7 @@ serviceDefinition:
   metadata: {}
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 asyncAccepted: true

--- a/src/test/resources/tenant-aware/expected_binding.yml
+++ b/src/test/resources/tenant-aware/expected_binding.yml
@@ -3,7 +3,7 @@ bindingId: "77643a12-a1d1-4717-abcd-9d66448a2148"
 serviceInstanceId: "e4bd6a78-7e05-4d5a-97b8-f8c5d1c710ab"
 serviceDefinitionId: "d40133dd-8373-4c25-8014-fde98f38a728"
 planId: "a13edcdf-eb54-44d3-8902-8f24d5acb07e"
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 parameters: {}

--- a/src/test/resources/tenant-aware/expected_instance.yml
+++ b/src/test/resources/tenant-aware/expected_instance.yml
@@ -31,7 +31,7 @@ serviceDefinition:
     tenantAware: true
   requires: []
   dashboardClient: null
-originatingIdentity: !<PlatformContext>
+originatingIdentity:
   platform: null
   user: "unittester"
 asyncAccepted: true


### PR DESCRIPTION
I try to solve https://github.com/meshcloud/unipipe-service-broker/issues/69. However, the the YAMLGenerator config option to disable types tagging inlines tags. For originatingIdentity, we end up with two platform keys, which makes the resulting the YAML invalid. Therefore this PR is marked as draft.