### PR TITLE
Don't run as root in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #   - at least docker 19.03
 #   - docker buildkit enabled (export DOCKER_BUILDKIT=1)
 
-FROM eclipse-temurin:17-jdk as builder
+FROM eclipse-temurin:17-jdk AS builder
 
 COPY ./ /build
 
@@ -15,9 +15,17 @@ WORKDIR /build
 RUN ./gradlew :bootJar -x test
 
 FROM eclipse-temurin:17-jre
+ARG UID=1005
 
-COPY --from=builder /build/build/libs/unipipe-service-broker-1.0.0.jar /app/
+COPY --chown=0:0 --chmod=555 --from=builder /build/build/libs/unipipe-service-broker-1.0.0.jar /app/
 
 WORKDIR /app
+
+RUN useradd -u $UID -ms /bin/bash unipipe && \
+    chown $UID /app
+
+USER $UID
+
+EXPOSE 8075
 
 ENTRYPOINT [ "/app/unipipe-service-broker-1.0.0.jar" ]


### PR DESCRIPTION
It is considered bad practice to let applications run as root in a Docker container. Furthermore, this might even be prohibited in some environments. In order to lower the attack surface, the application is executed as an unprivileged user with this PR.