### PR TITLE
Set credentials provider for fetchMergePush, add common helper for HTTP authentication and improve Git operations

### DIFF
--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
@@ -121,7 +121,13 @@ open class GitHandlerService(
   private fun fetchMergePush(): Boolean {
     // fetch from the remote
     git.fetch()
-        .apply { remote = "origin" }
+        .apply {              
+          remote = "origin" 
+
+          gitConfig.username?.let {
+            setCredentialsProvider(UsernamePasswordCredentialsProvider(gitConfig.username, gitConfig.password))
+          }
+        }
         .call()
 
     // merge changes - this happens locally in our repository


### PR DESCRIPTION
This is a continuation of my [colleague's PR](https://github.com.mcas.ms/meshcloud/unipipe-service-broker/pull/138)

Attempting to resolve [requested changes](https://github.com/meshcloud/unipipe-service-broker/pull/138#discussion_r2059203897) I introduced a common top-level function to handle git credentials from the gitConfig object in both the GitHandlerService class and its companion object.

(I am new to kotlin, so unsure if this is the way to go in these cases, as class methods seem to be unavailable to companion objects?)